### PR TITLE
Update Nvidia key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM pytorch/pytorch:1.7.1-cuda11.0-cudnn8-devel
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update \
  && apt-get install ffmpeg libsm6 libxext6 libopenblas-dev -y
 


### PR DESCRIPTION
The Nvidia key has changed, and this `Dockerfile` cannot build successfully. This commit update Nvidia key to allow update the apt repository successfully.

More details: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/